### PR TITLE
updated Gemfile to avoid errors in openshift during build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,5 +59,5 @@ gem 'tiddle'
 gem 'octokit', '~> 4.0'
 gem 'github-markup'
 
-gem 'commonmarker' # Needed to render markdown github style
+# gem 'commonmarker' # Needed to render markdown github style
 gem 'json-schema'


### PR DESCRIPTION
The gem commonmarker is used to convert markdown into html.

Currently it doesn't work in openshift as it depends on cmake and the library is not included in the base image.

